### PR TITLE
Lazy computed-signals in Haptic Wire

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,7 +3,7 @@ import esbuild from 'esbuild';
 const externalPlugin = {
   name: 'external',
   setup(build) {
-    build.onResolve({ filter: /\.\/(h|w)$/ }, args => {
+    build.onResolve({ filter: /\.\/(h|w)$/ }, (args) => {
       // Resolve as 'h' or 'w'
       const lastChar = args.path[args.path.length - 1];
       return { path: `./${lastChar}`, external: true };
@@ -16,6 +16,14 @@ const shared = {
   bundle: true,
   sourcemap: true,
   minify: true,
+  // About 100 characters saved this way
+  define: {
+    STATE_OFF: 0,
+    STATE_ON: 1,
+    STATE_RUNNING: 2,
+    STATE_PAUSED: 3,
+    STATE_STALE: 4,
+  },
 };
 
 Promise.all([
@@ -38,7 +46,7 @@ Promise.all([
     ...shared,
   }),
 ])
-  .catch(err => {
+  .catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -12,8 +12,7 @@ import {
 const data = wireSignals({
   text: '',
   count: 0,
-  // OHNO! $ might be undefined, and then data.count will write undefined...
-  countSquared: ($: SubToken) => data.count($) ** 2,
+  countSquared: wR(($) => data.count($) ** 2),
 });
 
 // @ts-ignore

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
 import { h, api } from '../src/index.js';
 import { wS, wR } from '../src/w/index.js';
 import type { WireReactor, WireSignal, SubToken } from '../src/w/index.js';

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,7 +1,7 @@
 import { h, api } from '../src/index.js';
 import { wireSignals, wR } from '../src/w/index.js';
 
-import type { WireSignal } from '../src/w/index.js';
+import type { WireSignal, SubToken } from '../src/w/index.js';
 
 import {
   regDebugRender,
@@ -12,7 +12,12 @@ import {
 const data = wireSignals({
   text: '',
   count: 0,
+  // OHNO! $ might be undefined, and then data.count will write undefined...
+  countSquared: ($: SubToken) => data.count($) ** 2,
 });
+
+// @ts-ignore
+window.data = data;
 
 // TODO: insert.patch(el, value) and property.patch(el, prop, value)
 api.patchHandler = regDebugPatchHandler;
@@ -26,6 +31,10 @@ const externallyDefinedReactorTest = wR(($) => {
 const Page = () =>
   <main>
     <p>This has been clicked {wR(data.count)} times</p>
+    <p>Squared, that's {data.countSquared()}</p>
+    {/* This currently, incorrectly, returns the function rather than calling it
+    until you pass it back into itself because it's wired to understand writes
+    only, not the initial creation */}
     <input
       placeholder='Type something...'
       value={wR(data.text)}

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,26 +1,30 @@
 import { h, api } from '../src/index.js';
 import { wireSignals, wR } from '../src/w/index.js';
 
-import type { WireSignal, SubToken } from '../src/w/index.js';
-
 import {
   regDebugRender,
   regDebugPatchHandler,
   regDebugTrackSignalSubscriptions
 } from './registryDebugging.js';
 
-const data = wireSignals({
+const s1 = wireSignals({
   text: '',
   count: 0,
-  countSquared: wR(($) => data.count($) ** 2),
 });
+const c1 = wireSignals({
+  countSquared: wR(($) => s1.count($) ** 2),
+});
+const c2 = wireSignals({
+  countSquaredSquared: wR(($) => c1.countSquared($) ** 2),
+});
+const data = { ...s1, ...c1, ...c2 };
 
 // @ts-ignore
 window.data = data;
 
 // TODO: insert.patch(el, value) and property.patch(el, prop, value)
 api.patchHandler = regDebugPatchHandler;
-regDebugTrackSignalSubscriptions(Object.values(data) as WireSignal[]);
+regDebugTrackSignalSubscriptions(Object.values(data));
 
 const externallyDefinedReactorTest = wR(($) => {
   return `data.text chars: ${data.text($).length}; `

--- a/examples/index.tsx
+++ b/examples/index.tsx
@@ -1,5 +1,5 @@
 import { h, api } from '../src/index.js';
-// import { wS, wR } from '../src/w/index.js';
+import { wireSignals, wR } from '../src/w/index.js';
 import type { WireReactor, WireSignal, SubToken } from '../src/w/index.js';
 
 import {
@@ -8,77 +8,24 @@ import {
   regDebugTrackSignalSubscriptions
 } from './registryDebugging.js';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-declare type X = any;
-declare function wR<T>(fn: ($: SubToken) => T): WireReactor<T>;
-
-declare function wS1<T extends {
-  [K in keyof T]: (() => X) | T[K]
-}>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends () => () => infer R ? R : T[K]>;
-}
-const data1 = wS1({
-  text: '',
-  count: 0,
-  countPlusOne: () => () => data1.count() + 1,
-  countPlusTwo: () => () => data1.countPlusOne() + 1,
-});
-
-// This works. Least verbose working version...
-declare function wS2<T extends {
-  [K in keyof T]: (($: SubToken) => X) | T[K]
-}>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends ($: SubToken) => () => infer R ? R : T[K]>;
-}
-const data2 = wS2({
-  text: '',
-  count: 0,
-  countPlusOne: ($) => () => data2.count($) + 1,
-  countPlusTwo: ($) => () => data2.countPlusOne($) + 1,
-});
-
-// This works. Somewhat verbose...
-declare function wS3<T extends {
-  [K in keyof T]: (($: SubToken) => X) | T[K]
-}>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends ($: SubToken) => infer R ? R : T[K]>;
-}
-const data3 = wS3({
+// I actually filed a bug TypeScript #43683
+const data = wireSignals({
   text: '',
   count: 0,
   countPlusOne($): number {
-    return data3.count($) + 1;
+    return data.count($) + 1;
   },
   countPlusTwo($): number {
-    return data3.countPlusOne($) + 1;
+    return data.countPlusOne($) + 1;
   },
 });
-
-// This works. Extremely verbose though...
-declare function wS4<T extends {
-  [K in keyof T]: (() => WireReactor<X>) | T[K]
-}>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends () => WireReactor<infer R> ? R : T[K]>;
-}
-const data4 = wS4({
-  text: '',
-  count: 0,
-  countPlusOne(): WireReactor<number> {
-    return wR(($) => data4.count($) + 1);
-  },
-  countPlusTwo(): WireReactor<number> {
-    return wR(($) => data4.countPlusOne($) + 1);
-  },
-});
-
-const data = data4;
 
 // @ts-ignore
 window.data = data;
 
 // TODO: insert.patch(el, value) and property.patch(el, prop, value)
 api.patchHandler = regDebugPatchHandler;
-regDebugTrackSignalSubscriptions(Object.values(data));
+regDebugTrackSignalSubscriptions(Object.values(data) as WireSignal[]);
 
 const externallyDefinedReactorTest = wR(($) => {
   return `data.text chars: ${data.text($).length}; `

--- a/examples/registryDebugging.ts
+++ b/examples/registryDebugging.ts
@@ -40,7 +40,7 @@ const regDebugPatchHandler: typeof api.patchHandler = (expr, updateCallback) => 
 const regDebugTrackSignalSubscriptions = (signals: WireSignal[]) => {
   signals.forEach((signal) => {
     console.log(`Tracking ${signal.name}`);
-    const set = signal.wR;
+    const set = signal.rS;
     // Intercept the prototype functions...
     const addFn = set.add.bind(set);
     set.add = function(wR) {
@@ -66,8 +66,9 @@ function snapshotRegistry() {
     snapshot[reactor.name] = {
       /* eslint-disable key-spacing */
       fn: reactor.fn.toString(),
-      rS: [...reactor.rS].map((x) => x.name),
-      rP: [...reactor.rP].map((x) => x.name),
+      sRS: [...reactor.sRS].map((x) => x.name),
+      sRP: [...reactor.sRP].map((x) => x.name),
+      sXS: [...reactor.sXS].map((x) => x.name),
       inner: [...reactor.inner].map((x) => x.name),
       runs: reactor.runs,
       depth: reactor.depth,
@@ -76,7 +77,7 @@ function snapshotRegistry() {
         'ON',
         'RUNNING',
         'PAUSED',
-        'PAUSED_STALE',
+        'STALE',
       ][reactor.state],
     };
   });

--- a/examples/server.js
+++ b/examples/server.js
@@ -12,6 +12,14 @@ esbuild
     format: 'esm',
     bundle: true,
     write: false,
+    // About 100 characters saved this way
+    define: {
+      STATE_OFF: 0,
+      STATE_ON: 1,
+      STATE_RUNNING: 2,
+      STATE_PAUSED: 3,
+      STATE_STALE: 4,
+    },
   })
   .then((sr) => {
     console.log(`Listening on http://${sr.host}:${sr.port}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,9 +51,9 @@ const svg = <T extends () => Element>(closure: T): ReturnType<T> => {
 const when = <T extends string>(
   condition: WireSignal<T>,
   views: { [k in T]?: Component }
-): WireReactor => {
+): WireReactor<El | undefined> => {
   const renderedElements = {} as { [k in T]?: El };
-  const renderedReactors = {} as { [k in T]?: WireReactor };
+  const renderedReactors = {} as { [k in T]?: WireReactor<void> };
   let condActive: T;
   return wR(($) => {
     const cond = condition($);
@@ -77,10 +77,13 @@ const when = <T extends string>(
 
 export { h, api, svg, when };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type DistributeWireReactorType<T> = T extends any ? WireReactor<T> : never;
+
 declare namespace h {
   export namespace JSX {
-    type MaybeReactor<T> = T | WireReactor<T>;
-    type AllowReactorForProperties<T> = { [K in keyof T]: MaybeReactor<T[K]> };
+    type MaybeSomeReactor<T> = T | DistributeWireReactorType<T>;
+    type AllowReactorForProperties<T> = { [K in keyof T]: MaybeSomeReactor<T[K]> };
 
     type Element = HTMLElement | SVGElement | DocumentFragment;
 
@@ -99,8 +102,8 @@ declare namespace h {
     type HTMLAttributes<Target extends EventTarget>
       = AllowReactorForProperties<Omit<HTMLAttrs, 'style'>>
         & { style?:
-            | MaybeReactor<string>
-            | { [key: string]: MaybeReactor<string | number> };
+            | MaybeSomeReactor<string>
+            | { [key: string]: MaybeSomeReactor<string | number> };
           }
         & DOMAttributes<Target>;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,11 +26,7 @@ type Component = (...args: unknown[]) => El;
 
 // TODO: insert.patch(el, value) and property.patch(el, prop, value)
 
-api.patchTest = (expr) => {
-  // Perflink benchmark says using reactorRegistry's Set.has() would be ~20%
-  // slower than Function#name's String.startsWith()
-  return typeof expr === 'function' && expr.name.startsWith('wR#');
-};
+api.patchTest = (expr) => (expr && (expr as { $wR: 1 }).$wR) as boolean;
 
 api.patchHandler = (expr, updateCallback) => {
   const prevFn = (expr as WireReactor).fn;

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -80,7 +80,7 @@ declare const STATE_STALE   = 4;
 // which is useful for debugging
 
 const wireReactor = <T>(fn: ($: SubToken) => T): WireReactor<T> => {
-  const id = `wR#${reactorId++}(${fn.name})`;
+  const id = `wR:${reactorId++}{${fn.name}}`;
   let saved: T;
   // @ts-ignore rS,rP,inner,state are setup by reactorUnsubscribe() below
   const wR: WireReactor<T> = { [id]() {
@@ -145,7 +145,7 @@ const wireSignals = <T>(obj: T): {
   Object.keys(obj).forEach((k) => {
     let saved: unknown;
     let read: WireReactor<X> | boolean | undefined; // Multi-use temp variable
-    const id = `wS#${signalId++}(${k})`;
+    const id = `wS:${signalId++}{${k}}`;
     const wS = { [id](...args: (SubToken | unknown)[]) {
       // Case: Read-Subscribe
       // eslint-disable-next-line no-cond-assign

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -69,12 +69,12 @@ const reactorTokenMap = new WeakMap<SubToken, WireReactor<X>>();
 
 // Symbol() doesn't gzip well. `[] as const` gzips best but isn't debuggable
 // without a lookup Map<> and other hacks.
-const STATE_OFF     = 0;
-const STATE_ON      = 1;
-const STATE_RUNNING = 2;
-const STATE_PAUSED  = 3;
+declare const STATE_OFF     = 0;
+declare const STATE_ON      = 1;
+declare const STATE_RUNNING = 2;
+declare const STATE_PAUSED  = 3;
 // Reactor runs are skipped if they're paused or they're for a computed signal
-const STATE_STALE   = 4;
+declare const STATE_STALE   = 4;
 
 // In wireSignal and wireReactor `{ [id]() {} }[id]` preserves the function name
 // which is useful for debugging

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -121,12 +121,12 @@ const reactorPause = (wR: WireReactor) => {
 const wireSignals = <T extends O>(obj: T): { [K in keyof T]: WireSignal<T[K]>; } => {
   type V = T[keyof T];
   Object.keys(obj).forEach((k) => {
-    let saved = obj[k];
+    let saved: V;
     // Used for reactorTokenMap but also as a temporary variable in case Write-A
     let subReactor: WireReactor | undefined;
     let computedSignalReactor: WireReactor | undefined;
     // Batch the identifier since key k will be unique
-    const id = `wS#${signalId}(${k})`;
+    const id = `wS#${signalId++}(${k})`;
     const wS = { [id](...args: (V | SubToken)[]) {
       // Case: Read-Pass
       if (!args.length) {
@@ -196,14 +196,14 @@ const wireSignals = <T extends O>(obj: T): { [K in keyof T]: WireSignal<T[K]>; }
           });
         }
       }
-      // TODO: Need to actually call the computed-signal...Not only on write
       return saved;
     } }[id] as WireSignal<V>;
     wS.wR = new Set<WireReactor>();
-    // @ts-ignore
+    // Run. This triggers functions and computeds
+    wS(obj[k] as V);
+    // @ts-ignore Mutate object type in place, sorry not sorry
     obj[k] = wS;
   });
-  signalId++;
   return obj as { [K in keyof T]: WireSignal<T[K]>; };
 };
 

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -139,9 +139,8 @@ const wireSignals = <T extends O>(obj: T): { [K in keyof T]: WireSignal<T[K]>; }
   type V = T[keyof T];
   Object.keys(obj).forEach((k) => {
     let saved: V;
-    let savedComputed: V;
-    let reactorFromToken: WireReactor<X> | undefined;
-    // Batch the identifier since key k will be unique
+    let savedForComputed: V | undefined;
+    let reactorForToken: WireReactor<X> | undefined;
     const id = `wS#${signalId++}(${k})`;
     const wS = { [id](...args: (V | SubToken)[]) {
       // Case: Read-Pass
@@ -155,12 +154,12 @@ const wireSignals = <T extends O>(obj: T): { [K in keyof T]: WireSignal<T[K]>; }
       }
       // Case: Read-Sub; could be any reactor not necessarily `reactorActive`
       // eslint-disable-next-line no-cond-assign
-      else if (reactorFromToken = reactorTokenMap.get(args[0] as SubToken)) {
-        if (reactorFromToken.rP.has(wS)) {
+      else if (reactorForToken = reactorTokenMap.get(args[0] as SubToken)) {
+        if (reactorForToken.rP.has(wS)) {
           throw new Error(`Mixed rP/rS ${wS.name}`);
         }
-        reactorFromToken.rS.add(wS);
-        wS.wR.add(reactorFromToken);
+        reactorForToken.rS.add(wS);
+        wS.wR.add(reactorForToken);
       }
       // Case: Write but during a transaction (arg is V)
       else if (transactionSignals) {

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -63,8 +63,7 @@ let activeReactor: WireReactor<X> | undefined;
 // WireSignals written to during a transaction(() => {...})
 let transactionSignals: Set<WireSignal<X>> | undefined;
 
-// Registry is a Set, not WeakSet, because it should be iterable
-const reactorRegistry = new Set<WireReactor<X>>();
+// Lookup $ to find which reactor it refers to
 const reactorTokenMap = new WeakMap<SubToken, WireReactor<X>>();
 
 // Symbol() doesn't gzip well. `[] as const` gzips best but isn't debuggable
@@ -112,7 +111,6 @@ const wireReactor = <T>(fn: ($: SubToken) => T): WireReactor<T> => {
   wR.fn = fn;
   wR.runs = 0;
   wR.depth = activeReactor ? activeReactor.depth + 1 : 0;
-  reactorRegistry.add(wR);
   if (activeReactor) activeReactor.inner.add(wR);
   reactorUnsubscribe(wR);
   return wR;
@@ -251,7 +249,6 @@ export {
   wireSignals as wS,
   wireReactor,
   wireReactor as wR,
-  reactorRegistry,
   reactorUnsubscribe,
   reactorPause,
   transaction,

--- a/src/w/index.ts
+++ b/src/w/index.ts
@@ -139,8 +139,11 @@ const reactorPause = (wR: WireReactor<X>) => {
 // } => {
 // type WithWildcards<T> = T & { [key: string]: unknown };
 // type UnpackReactorFnReturn<T> = T extends ($: SubToken) => infer R ? R : T;
-const wireSignals = <T extends O>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends WireReactor<infer R> ? R : T[K]>;
+// type MaybeSubFn<Val> = Val extends (...args: X[]) => infer R ? ($: SubToken) => R : number;
+const wireSignals = <T extends {
+  [K in keyof T]: (($: SubToken) => X) | T[K]
+}>(obj: T): {
+  [K in keyof T]: WireSignal<T[K] extends ($: SubToken) => infer R ? R : T[K]>;
 } => {
   type V = T[keyof T];
   Object.keys(obj).forEach((k) => {


### PR DESCRIPTION
This implements lazy computeds. Similar to the computeds found in Sinuous but these are lazy, explicitly defined, and are true `WireSignal` functions. They're defined with a `WireReactor`, but unlike a reactor, they don't evaluate on each signal write.

A computed-signal is a normal signal backed by a reactor (called a computed-reactor). This is a pairing.

It's different than:

```typescript
// Not a lazy computed-signal!
const data = wS({
  count: 0,
  countPlusOne: null
});
wR($ => {
  console.log("Sending out a new countPlusOne");
  data.countPlusOne(data.count($) + 1);
});
```

This runs every write, even if no one is reading/observing `data.countPlusOne`. This is because a `wR` **is** an observer, so as far as Haptic can tell, it's worth executing. With computed-signals, the computed-reactor isn't worth executing unless it has observers aka a non-computed reactor.

When a signal inside a computed updates, the signal marks the computed as stale rather than executing it. When it is finally executed, it uses this stale flag to cache the calculation. This leads to the least amount of work performed.

TypeScript #43683 helped me figure out the API design. There are notes directly in the code about the reasoning and why I thought it was worth it to settle on the version that (unfortunately) requires manually specifying the reactor return type - it's the best of many not great options due to limitations in the TS compiler.

```typescript
const data = wS({
  text: '',
  count: 0,
  // Lazy computed-signals
  countPlusOne: wR(($): number => data.count($) + 1),
  countPlusTwo: wR(($): number => data.countPlusOne($) + 1),
});
```

If I cut out `when()` and `svg()` utilities, and import wR & wS into the main bundle, the size is **1570b min+gz for haptic and 805b min+gz for only haptic/w**. This is everything, so hopefully I can keep Haptic around 1.6kb. The down side is this PR adds a lot of complexity. Wire was originally really nicely coupled - two paired functions that share a bit of global state and some helper methods. This shoves a new type of function into the definitions of both signals and reactors: it's not a third type, it's teaching them both to do a new dance. This adds a lot of new code branches and checks. Still, I think it's worth it because I've been chasing lazy computeds for at least a year in Sinuous.