### PR TITLE
Improve naming of properties and exports in Haptic Wire

### DIFF
--- a/build.js
+++ b/build.js
@@ -35,7 +35,7 @@ esbuild.build({
   metafile: true,
   // About 100 characters saved this way
   define: {
-    STATE_CLEARED: 0,
+    STATE_RESET: 0,
     STATE_RUNNING: 1,
     STATE_LINKED_WAITING: 2,
     STATE_LINKED_PAUSED: 3,

--- a/build.js
+++ b/build.js
@@ -35,11 +35,11 @@ esbuild.build({
   metafile: true,
   // About 100 characters saved this way
   define: {
-    STATE_OFF: 0,
-    STATE_ON: 1,
-    STATE_RUNNING: 2,
-    STATE_PAUSED: 3,
-    STATE_STALE: 4,
+    STATE_CLEARED: 0,
+    STATE_RUNNING: 1,
+    STATE_LINKED_WAITING: 2,
+    STATE_LINKED_PAUSED: 3,
+    STATE_LINKED_STALE: 4,
   },
 })
   .then((build) => Promise.all(

--- a/build.js
+++ b/build.js
@@ -37,9 +37,9 @@ esbuild.build({
   define: {
     STATE_RESET: 0,
     STATE_RUNNING: 1,
-    STATE_LINKED_WAITING: 2,
-    STATE_LINKED_PAUSED: 3,
-    STATE_LINKED_STALE: 4,
+    STATE_WIRED_WAITING: 2,
+    STATE_WIRED_PAUSED: 3,
+    STATE_WIRED_STALE: 4,
   },
 })
   .then((build) => Promise.all(

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "types": "tsc --project tsconfig.json",
-    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_OFF=0 --define:STATE_ON=1 --define:STATE_RUNNING=2 --define:STATE_PAUSED=3 --define:STATE_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
+    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_CLEARED=0 --define:STATE_RUNNING=1 --define:STATE_LINKED_WAITING=2 --define:STATE_LINKED_PAUSED=3 --define:STATE_LINKED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "types": "tsc --project tsconfig.json",
-    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_RESET=0 --define:STATE_RUNNING=1 --define:STATE_LINKED_WAITING=2 --define:STATE_LINKED_PAUSED=3 --define:STATE_LINKED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
+    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_RESET=0 --define:STATE_RUNNING=1 --define:STATE_WIRED_WAITING=2 --define:STATE_WIRED_PAUSED=3 --define:STATE_WIRED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "node build.js",
     "types": "tsc --project tsconfig.json",
-    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_CLEARED=0 --define:STATE_RUNNING=1 --define:STATE_LINKED_WAITING=2 --define:STATE_LINKED_PAUSED=3 --define:STATE_LINKED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
+    "bundlesize": "echo $(esbuild --bundle src/index.ts --format=esm --minify --define:STATE_RESET=0 --define:STATE_RUNNING=1 --define:STATE_LINKED_WAITING=2 --define:STATE_LINKED_PAUSED=3 --define:STATE_LINKED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.22.0",

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ developers who are trying to learn.
 
 There's minimum hidden complexity in Haptic. It's ~500 lines of source code; 220
 of which is the single-file reactivity engine called haptic/w. Reactivity is
-wired into a page explicitly by subscribing signals and reactors. This is then
+wired into a page explicitly by subscribing signals and cores. This is then
 debuggable at runtime with proper naming and lookups.
 
 Its first goal is to setup non-developers (i.e partners/friends) on the path to

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,13 +28,13 @@ import type { GenericEventAttrs, HTMLAttrs, SVGAttrs, HTMLElements, SVGElements 
 
 api.patch = (value, patchDOM) => {
   // @ts-ignore
-  const $wR = (value && value.$wR) as boolean;
+  const $wC = (value && value.$wC) as boolean;
   const { fn } = value as WireCore;
-  if ($wR && patchDOM) {
+  if ($wC && patchDOM) {
     (value as WireCore).fn = ($) => patchDOM(fn($));
     (value as WireCore)();
   }
-  return $wR;
+  return $wC;
 };
 
 export { h, api, signalsFrom, core };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 
 import { h, api } from './dom';
 // TODO: Actually split the import sites. This is only for `npm run size:bundle`
-import { signalState, sub } from './wire';
+import { signalObject, sub } from './wire';
 
 import type { WireSubscriber } from './wire';
 import type { GenericEventAttrs, HTMLAttrs, SVGAttrs, HTMLElements, SVGElements } from './jsx';
@@ -37,7 +37,7 @@ api.patch = (value, patchDOM) => {
   return $wR;
 };
 
-export { h, api, signalState, sub };
+export { h, api, signalObject, sub };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DistributeSubscriberT<T> = T extends any ? WireSubscriber<T> : never;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@
 
 import { h, api } from './dom';
 // TODO: Actually split the import sites. This is only for `npm run size:bundle`
-import { signalPackage, sub } from './wire';
+import { signalState, sub } from './wire';
 
 import type { WireSubscriber } from './wire';
 import type { GenericEventAttrs, HTMLAttrs, SVGAttrs, HTMLElements, SVGElements } from './jsx';
@@ -37,7 +37,7 @@ api.patch = (value, patchDOM) => {
   return $wR;
 };
 
-export { h, api, signalPackage, sub };
+export { h, api, signalState, sub };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DistributeSubscriberT<T> = T extends any ? WireSubscriber<T> : never;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -36,10 +36,10 @@ const when = <T extends string>(
         // Then unpause. If nothing changed then no core.sS/core.sP links change
         (liveCores[cond] as WireCore)();
       }
-      // Able to render?
-      const wCNew = core(() => {});
-      liveElements[cond] = coreAdopt(wCNew, () => h(views[cond] as Component));
-      liveCores[cond] = wCNew;
+      // Able to render this DOM tree?
+      const coreForTree = core(() => {});
+      liveElements[cond] = coreAdopt(coreForTree, () => h(views[cond] as Component));
+      liveCores[cond] = coreForTree;
     }
     return liveElements[cond] as El | undefined;
   };

--- a/src/utils/readme.md
+++ b/src/utils/readme.md
@@ -24,31 +24,31 @@ cosnt <Page> = () =>
 document.body.appendChild(<Page/>);
 ```
 
-**`when(condition: WireReactor<T>, views: { [key: T]: () => Node })`**
+**`when(wC: WireCore<T>, views: { [key: T]: () => Node })`**
 
-Renders a DOM node by matching the `condition` reactors's value to an object key
-in `views`. Useful when paired with a reactor which returns a nice value such as
-"T"/"F" shown below. When a view is asked to unrender, all nested reactors are
-paused so the view won't update while off screen. The DOM nodes are still cached
-and held in memory, however.
+Renders a DOM node by matching the response of `wC` to an object key in `views`.
+Useful when paired with a core which returns a nice value such as "T"/"F" shown
+below. When a view is asked to unrender, all nested cores are paused so the view
+won't update while off screen. The DOM nodes are still cached and held in
+memory, however.
 
 Usage:
 
 ```tsx
 import { h } from 'haptic';
-import { wireSignals, wireReactor as wR } from 'haptic/wire';
+import { signalsFrom, core } from 'haptic/wire';
 import { when } from 'haptic/utils';
 
-const data = wireSignals({
+const data = signalsFrom({
   count: 0,
 });
 
 const Page = () =>
   <div>
     <p>Content below changes when <code>data.count > 5</code></p>
-    {when(wR($ => data.count($) > 5 ? "T" : "F"), {
+    {when(core($ => data.count($) > 5 ? "T" : "F"), {
       T: () => <p>There have been more than 5 clicks</p>,
-      F: () => <p>Current click count is {wR(data.count)}</p>,
+      F: () => <p>Current click count is {core(data.count)}</p>,
     })}
   </div>;
 

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -6,19 +6,19 @@ type WireCore<T = unknown> = {
   /** User-provided function to run */
   fn: ($: SubToken) => T;
   /** Signals that were read-subscribed last run */
-  sS: Set<WireSignal<X>>;
+  signalsRS: Set<WireSignal<X>>;
   /** Signals that were read-passed last run */
-  sP: Set<WireSignal<X>>;
-  /** Signals that were given by computed-signals last run */
-  sC: Set<WireSignal<X>>;
-  /** Other cores created during this run (children of this parent) */
+  signalsRP: Set<WireSignal<X>>;
+  /** Signals that were inherited from computed-signals last run */
+  signalsIC: Set<WireSignal<X>>;
+  /** Cores created during this run (children of this parent) */
   inner: Set<WireCore<X>>;
   /** FSM state: RESET|RUNNING|WAITING|PAUSED|STALE */
   state: CoreStates;
   /** Number of parent cores (see wR.inner); to sort core runs */
   sort: number;
   /** Run count */
-  runs: number;
+  run: number;
   /** If part of a computed signal, this is its signal */
   cS?: WireSignal<T>;
   /** To check "if x is a core" */
@@ -33,9 +33,9 @@ type WireSignal<T = unknown> = {
   /** Read value & subscribe */
   ($: SubToken): T;
   /** Cores subscribed to this signal */
-  rS: Set<WireCore<X>>;
+  cores: Set<WireCore<X>>;
   /** Transaction value; set and deleted on commit */
-  tV?: T;
+  next?: T;
   /** If this is a computed-signal, this is its core */
   cC?: WireCore<T>;
   /** To check "if x is a signal" */
@@ -56,9 +56,9 @@ type SubToken = {
 type CoreStates =
   | typeof STATE_RESET
   | typeof STATE_RUNNING
-  | typeof STATE_LINKED_WAITING
-  | typeof STATE_LINKED_PAUSED
-  | typeof STATE_LINKED_STALE;
+  | typeof STATE_WIRED_WAITING
+  | typeof STATE_WIRED_PAUSED
+  | typeof STATE_WIRED_STALE;
 
 /* eslint-disable no-multi-spaces */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -69,16 +69,16 @@ let signalId = 0;
 
 // Currently running core
 let activeCore: WireCore<X> | undefined;
-// WireSignals written to during a transaction(() => {...})
+// WireSignals written to during a transaction
 let transactionSignals: Set<WireSignal<X>> | undefined;
 
 // Symbol() doesn't gzip well. `[] as const` gzips best but isn't debuggable
 // without a lookup Map<> and other hacks.
-declare const STATE_RESET          = 0;
-declare const STATE_RUNNING        = 1;
-declare const STATE_LINKED_WAITING = 2;
-declare const STATE_LINKED_PAUSED  = 3;
-declare const STATE_LINKED_STALE   = 4;
+declare const STATE_RESET         = 0;
+declare const STATE_RUNNING       = 1;
+declare const STATE_WIRED_WAITING = 2;
+declare const STATE_WIRED_PAUSED  = 3;
+declare const STATE_WIRED_STALE   = 4;
 
 /**
  * Void subcription token. Used when a function demands a token but you don't
@@ -94,7 +94,7 @@ const v$: SubToken = ((...signals) => signals.map((sig) => sig(v$)));
  * read-subscribed during its run will re-run the core when they're written to.
  * Cores are named by their function's name and a counter. */
 const core = <T>(fn: ($: SubToken) => T): WireCore<T> => {
-  const id = `core:${coreId++}{${fn.name}}`;
+  const id = `wC:${coreId++}{${fn.name}}`;
   let saved: T;
   // @ts-ignore function properties are setup by coreReset() below
   const wC: WireCore<T> = { [id]() {
@@ -103,7 +103,7 @@ const core = <T>(fn: ($: SubToken) => T): WireCore<T> => {
     }
     // If STATE_PAUSED then STATE_STALE was never reached; nothing has changed.
     // Restore state (below) and call inner cores so they can check
-    if (wC.state === STATE_LINKED_PAUSED) {
+    if (wC.state === STATE_WIRED_PAUSED) {
       wC.inner.forEach((_wC) => { _wC(); });
     } else {
       // Symmetrically remove all connections from wS/wR. Called "automatic
@@ -111,51 +111,51 @@ const core = <T>(fn: ($: SubToken) => T): WireCore<T> => {
       coreReset(wC);
       wC.state = STATE_RUNNING;
       saved = coreAdopt(wC, () => wC.fn($));
-      wC.runs++;
+      wC.run++;
     }
-    wC.state = wC.sS.size
-      ? STATE_LINKED_WAITING
+    wC.state = wC.signalsRS.size
+      ? STATE_WIRED_WAITING
       : STATE_RESET;
     return saved;
   } }[id];
   wC.$wC = 1;
   wC.fn = fn;
-  wC.runs = 0;
+  wC.run = 0;
   wC.sort = activeCore ? activeCore.sort + 1 : 0;
   // @ts-ignore
-  const $: SubToken = ((...wS) => wS.map((_signal) => _signal($)));
+  const $: SubToken = ((...wS) => wS.map((_wS) => _wS($)));
   $.$$ = 1;
   $.wC = wC;
   if (activeCore) activeCore.inner.add(wC);
-  coreInit(wC);
+  _initCore(wC);
   return wC;
 };
 
-const coreInit = (wC: WireCore<X>): void => {
+const _initCore = (wC: WireCore<X>): void => {
   wC.state = STATE_RESET;
   wC.inner = new Set();
   // Drop all signals now that they have been unlinked
-  wC.sS = new Set();
-  wC.sP = new Set();
-  wC.sC = new Set();
+  wC.signalsRS = new Set();
+  wC.signalsRP = new Set();
+  wC.signalsIC = new Set();
 };
 
 /**
  * Removes two-way subscriptions between its signals and itself. This also turns
  * off the core until it is manually re-run. */
 const coreReset = (wC: WireCore<X>): void => {
-  const unlinkFromSignal = (signal: WireSignal<X>) => signal.rS.delete(wC);
+  const unlinkFromSignal = (signal: WireSignal<X>) => signal.cores.delete(wC);
   wC.inner.forEach(coreReset);
-  wC.sS.forEach(unlinkFromSignal);
-  wC.sC.forEach(unlinkFromSignal);
-  coreInit(wC);
+  wC.signalsRS.forEach(unlinkFromSignal);
+  wC.signalsIC.forEach(unlinkFromSignal);
+  _initCore(wC);
 };
 
 /**
  * Pauses a core. Trying to run the core again will unpause; if no signals
  * were written during the pause then the run is skipped. */
 const corePause = (wC: WireCore<X>) => {
-  wC.state = STATE_LINKED_PAUSED;
+  wC.state = STATE_WIRED_PAUSED;
   wC.inner.forEach(corePause);
 };
 
@@ -163,15 +163,15 @@ const signal = <T>(value: T, id?: string): WireSignal<T> => {
   type R = WireCore<X>;
   let saved: unknown;
   // Multi-use temp variable
-  let read: unknown = `signal:${signalId++}{${id as string}`;
+  let read: unknown = `wS:${signalId++}{${id as string}`;
   const wS = { [read as string](...args: unknown[]) {
     // Case: Read-Pass
     if ((read = !args.length)) {
       if (activeCore) {
-        if (activeCore.sS.has(wS)) {
-          throw new Error(`Mixed sS|sP ${wS.name}`);
+        if (activeCore.signalsRS.has(wS)) {
+          throw new Error(`Mixed rs|rp ${wS.name}`);
         }
-        activeCore.sP.add(wS);
+        activeCore.signalsRP.add(wS);
       }
     }
     // Case: Void token
@@ -180,16 +180,16 @@ const signal = <T>(value: T, id?: string): WireSignal<T> => {
     // Case: Read-Subscribe
     // @ts-ignore
     else if ((read = args[0] && args[0].$$ && args[0].wR)) {
-      if ((read as R).sP.has(wS)) {
-        throw new Error(`Mixed sP|sS ${wS.name}`);
+      if ((read as R).signalsRP.has(wS)) {
+        throw new Error(`Mixed rp|rs ${wS.name}`);
       }
-      (read as R).sS.add(wS);
-      wS.rS.add((read as R));
+      (read as R).signalsRS.add(wS);
+      wS.cores.add((read as R));
       // Subscribing to a computed-signal also links cR's subscribed signals
-      wS.cC && wS.cC.sS.forEach((s) => {
-        // Link to sC not sS. This way the "Mixed A/B" errors keep working
-        (read as R).sC.add(s);
-        s.rS.add((read as R));
+      wS.cC && wS.cC.signalsRS.forEach((s) => {
+        // Link to sC not sS. This way the "Mixed A|B" errors keep working
+        (read as R).signalsIC.add(s);
+        s.cores.add((read as R));
       });
     }
     // Case: Write
@@ -197,7 +197,7 @@ const signal = <T>(value: T, id?: string): WireSignal<T> => {
       // If in a transaction; defer saving the value
       if (transactionSignals) {
         transactionSignals.add(wS);
-        wS.tV = args[0] as T;
+        wS.next = args[0] as T;
         return;
       }
       // If overwriting a computed-signal core, unsubscribe the core
@@ -208,33 +208,33 @@ const signal = <T>(value: T, id?: string): WireSignal<T> => {
       }
       saved = args[0] as T;
       // @ts-ignore If writing a core, this signal becomes as a computed-signal
-      if (saved && saved.$wR) {
+      if (saved && saved.$wC) {
         (saved as R).cS = wS;
-        (saved as R).state = STATE_LINKED_STALE;
+        (saved as R).state = STATE_WIRED_STALE;
         wS.cC = saved as R;
       }
-      // Notify. Copy wS.rS since the Set() can grow while running and loop
+      // Notify. Copy wS.cores since the Set() can grow while running and loop
       // infinitely. Depth ordering needs an array while Sinuous uses a Set()
-      const toRun = [...wS.rS].sort((a, b) => a.sort - b.sort);
+      const toRun = [...wS.cores].sort((a, b) => a.sort - b.sort);
       // Mark upstream computeds as stale. Must be in an isolated for-loop
       toRun.forEach((wC) => {
-        if (wC.state === STATE_LINKED_PAUSED || wC.cS) wC.state = STATE_LINKED_STALE;
+        if (wC.state === STATE_WIRED_PAUSED || wC.cS) wC.state = STATE_WIRED_STALE;
       });
       // Calls are ordered parent->child
       toRun.forEach((wC) => {
         // RESET|RUNNING|WAITING < PAUSED|STALE. Skips paused cores and lazy
         // computed-signals. RESET cores shouldn't exist...
-        if (wC.state < STATE_LINKED_PAUSED) wC();
+        if (wC.state < STATE_WIRED_PAUSED) wC();
       });
     }
     if (read) {
       // Re-run the core to get a new value if needed
-      if (wS.cC && wS.cC.state === STATE_LINKED_STALE) saved = wS.cC();
+      if (wS.cC && wS.cC.state === STATE_WIRED_STALE) saved = wS.cC();
       return saved;
     }
   } }[read as string] as WireSignal<T>;
   wS.$wS = 1;
-  wS.rS = new Set<WireCore<X>>();
+  wS.cores = new Set<WireCore<X>>();
   // Call it to run the "Case: Write" and de|initialize computed-signals
   wS(value);
   return wS;
@@ -275,16 +275,16 @@ const transaction = <T>(fn: () => T): T => {
   transactionSignals = prev;
   if (error) throw error;
   signals.forEach((wS) => {
-    wS(wS.tV);
-    delete wS.tV;
+    wS(wS.next);
+    delete wS.next;
   });
   return ret as T;
 };
 
 /**
  * Run a function with a core set as the active listener. Nested children cores
- * are adopted (see wR.sort and wR.inner). This also affects signal read
- * consistent checks for read-pass (sP) and read-subscribe (sS). */
+ * are adopted (see wR.sort and wR.inner). Also affects signal read consistency
+ * checks for read-pass (wS.signalsRP) and read-subscribe (wS.signalsRS). */
 const coreAdopt = <T>(wC: WireCore<X>, fn: () => T): T => {
   const prev = activeCore;
   activeCore = wC;

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -164,13 +164,15 @@ const subPause = (sub: WireSubscriber<X>) => {
  * hold a list of subscribed reactors. When any value is written reactors are
  * re-run. Writing a reactor to a signal creates a lazy computed-signal. Signals
  * are named by the key of the object entry and a global counter. */
-const signalState = <T>(obj: T): {
+const signalObject = <T>(obj: T): {
   [K in keyof T]: WireSignal<T[K] extends WireSubscriber<infer R> ? R : T[K]>;
 } => {
   Object.keys(obj).forEach((k) => {
     // @ts-ignore Mutation of T
     obj[k] = signal(obj[k as keyof T], k);
+    sigId--;
   });
+  sigId++;
   // @ts-ignore Mutation of T
   return obj;
 };
@@ -299,7 +301,7 @@ const subAdopt = <T>(sub: WireSubscriber<X>, fn: () => T): T => {
 
 export {
   signal,
-  signalState,
+  signalObject,
   sub,
   // None of these below contribute to bundle size
   subClear,

--- a/src/wire/index.ts
+++ b/src/wire/index.ts
@@ -1,6 +1,6 @@
 // Haptic Wire
 
-type WireReactor<T = unknown> = {
+type WireSubscriber<T = unknown> = {
   /** Run the reactor */
   (): T;
   /** User-provided function to run */
@@ -12,9 +12,9 @@ type WireReactor<T = unknown> = {
   /** Signals that were given by computed-signals last run */
   sC: Set<WireSignal<X>>;
   /** Other reactors created during this run (children of this parent) */
-  inner: Set<WireReactor<X>>;
-  /** FSM state: OFF|ON|RUNNING|PAUSED|STALE */
-  state: WireReactorState;
+  inner: Set<WireSubscriber<X>>;
+  /** FSM state: CLEARED|RUNNING|WAITING|PAUSED|STALE */
+  state: WireSubscriberState;
   /** Number of parent reactors (see wR.inner); to sort reactors runs */
   sort: number;
   /** Run count */
@@ -33,11 +33,11 @@ type WireSignal<T = unknown> = {
   /** Read value & subscribe */
   ($: SubToken): T;
   /** Reactors subscribed to this signal */
-  rS: Set<WireReactor<X>>;
+  rS: Set<WireSubscriber<X>>;
   /** Transaction value; set and deleted on commit */
   tV?: T;
   /** If this is a computed-signal, this is its reactor */
-  cR?: WireReactor<T>;
+  cR?: WireSubscriber<T>;
   /** To check "if x is a signal" */
   $wS: 1;
 };
@@ -48,44 +48,43 @@ type SubToken = {
     [P in keyof U]: U[P] extends WireSignal<infer R> ? R : never
   };
   /** Reactor to subscribe to */
-  wR: WireReactor<X>;
+  wR: WireSubscriber<X>;
   /** To check "if x is a subcription token" */
   $$: 1;
 };
 
-type WireReactorState =
-  | typeof STATE_OFF
-  | typeof STATE_ON
+type WireSubscriberState =
+  | typeof STATE_CLEARED
   | typeof STATE_RUNNING
-  | typeof STATE_PAUSED
-  | typeof STATE_STALE;
+  | typeof STATE_LINKED_WAITING
+  | typeof STATE_LINKED_PAUSED
+  | typeof STATE_LINKED_STALE;
 
 /* eslint-disable no-multi-spaces */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 type X = any;
 
-let signalId = 0;
-let reactorId = 0;
+let sigId = 0;
+let subId = 0;
 
 // Currently running reactor
-let activeReactor: WireReactor<X> | undefined;
+let activeSub: WireSubscriber<X> | undefined;
 // WireSignals written to during a transaction(() => {...})
 let transactionSignals: Set<WireSignal<X>> | undefined;
 
 // Symbol() doesn't gzip well. `[] as const` gzips best but isn't debuggable
 // without a lookup Map<> and other hacks.
-declare const STATE_OFF     = 0;
-declare const STATE_ON      = 1;
-declare const STATE_RUNNING = 2;
-declare const STATE_PAUSED  = 3;
-// Reactor runs are skipped if they're paused or they're for a computed signal
-declare const STATE_STALE   = 4;
+declare const STATE_CLEARED        = 0;
+declare const STATE_RUNNING        = 1;
+declare const STATE_LINKED_WAITING = 2;
+declare const STATE_LINKED_PAUSED  = 3;
+declare const STATE_LINKED_STALE   = 4;
 
 /**
  * Void subcription token. Used when a function demands a token but you don't
  * want to consent to any signal subscriptions. */
 // @ts-ignore
-const v$: SubToken = ((...wS) => wS.map((signal) => signal(v$)));
+const v$: SubToken = ((...signals) => signals.map((sig) => sig(v$)));
 
 // In wireSignal and wireReactor `{ [id]() {} }[id]` preserves the function name
 // which is useful for debugging
@@ -94,70 +93,70 @@ const v$: SubToken = ((...wS) => wS.map((signal) => signal(v$)));
  * Creates a reactor. Turn the reactor on by manually running it. Any signals
  * who read-subscribed will re-run the reactor when written to. Reactors are
  * named by their function's name and a counter. */
-const wireReactor = <T>(fn: ($: SubToken) => T): WireReactor<T> => {
-  const id = `wR:${reactorId++}{${fn.name}}`;
+const subscriber = <T>(fn: ($: SubToken) => T): WireSubscriber<T> => {
+  const id = `sub:${subId++}{${fn.name}}`;
   let saved: T;
   // @ts-ignore function properties are setup by reactorReset() below
-  const wR: WireReactor<T> = { [id]() {
-    if (wR.state === STATE_RUNNING) {
-      throw new Error(`Loop ${wR.name}`);
+  const sub: WireSubscriber<T> = { [id]() {
+    if (sub.state === STATE_RUNNING) {
+      throw new Error(`Loop ${sub.name}`);
     }
-    // If STATE_PAUSED then STATE_PAUSED_STALE was never reached; nothing has
-    // changed. Restore state (below) and call inner reactors so they can check
-    if (wR.state === STATE_PAUSED) {
-      wR.inner.forEach((reactor) => { reactor(); });
+    // If STATE_PAUSED then STATE_STALE was never reached; nothing has changed.
+    // Restore state (below) and call inner reactors so they can check
+    if (sub.state === STATE_LINKED_PAUSED) {
+      sub.inner.forEach((reactor) => { reactor(); });
     } else {
       // Symmetrically remove all connections from wS/wR. Called "automatic
       // memory management" in Sinuous/S.js
-      reactorUnsubscribe(wR);
-      wR.state = STATE_RUNNING;
-      saved = adopt(wR, () => wR.fn($));
-      wR.runs++;
+      subClear(sub);
+      sub.state = STATE_RUNNING;
+      saved = subAdopt(sub, () => sub.fn($));
+      sub.runs++;
     }
-    wR.state = wR.sS.size
-      ? STATE_ON
-      : STATE_OFF;
+    sub.state = sub.sS.size
+      ? STATE_LINKED_WAITING
+      : STATE_CLEARED;
     return saved;
   } }[id];
-  wR.$wR = 1;
-  wR.fn = fn;
-  wR.runs = 0;
-  wR.sort = activeReactor ? activeReactor.sort + 1 : 0;
+  sub.$wR = 1;
+  sub.fn = fn;
+  sub.runs = 0;
+  sub.sort = activeSub ? activeSub.sort + 1 : 0;
   // @ts-ignore
-  const $: SubToken = ((...wS) => wS.map((signal) => signal($)));
+  const $: SubToken = ((...wS) => wS.map((sig) => sig($)));
   $.$$ = 1;
-  $.wR = wR;
-  if (activeReactor) activeReactor.inner.add(wR);
-  reactorReset(wR);
-  return wR;
+  $.wR = sub;
+  if (activeSub) activeSub.inner.add(sub);
+  subInit(sub);
+  return sub;
 };
 
-const reactorReset = (wR: WireReactor<X>): void => {
-  wR.state = STATE_OFF;
-  wR.inner = new Set();
+const subInit = (sub: WireSubscriber<X>): void => {
+  sub.state = STATE_CLEARED;
+  sub.inner = new Set();
   // Drop all signals now that they have been unlinked
-  wR.sS = new Set();
-  wR.sP = new Set();
-  wR.sC = new Set();
+  sub.sS = new Set();
+  sub.sP = new Set();
+  sub.sC = new Set();
 };
 
 /**
  * Removes two-way subscriptions between its signals and itself. This also turns
  * off the reactor until it is manually re-run. */
-const reactorUnsubscribe = (wR: WireReactor<X>): void => {
-  const unlinkFromSignal = (signal: WireSignal<X>) => signal.rS.delete(wR);
-  wR.inner.forEach(reactorUnsubscribe);
-  wR.sS.forEach(unlinkFromSignal);
-  wR.sC.forEach(unlinkFromSignal);
-  reactorReset(wR);
+const subClear = (sub: WireSubscriber<X>): void => {
+  const unlinkFromSignal = (signal: WireSignal<X>) => signal.rS.delete(sub);
+  sub.inner.forEach(subClear);
+  sub.sS.forEach(unlinkFromSignal);
+  sub.sC.forEach(unlinkFromSignal);
+  subInit(sub);
 };
 
 /**
  * Pauses a reactor. Trying to run the reactor again will unpause; if no signals
  * were written during the pause then the run is skipped. */
-const reactorPause = (wR: WireReactor<X>) => {
-  wR.state = STATE_PAUSED;
-  wR.inner.forEach(reactorPause);
+const subPause = (sub: WireSubscriber<X>) => {
+  sub.state = STATE_LINKED_PAUSED;
+  sub.inner.forEach(subPause);
 };
 
 /**
@@ -165,91 +164,97 @@ const reactorPause = (wR: WireReactor<X>) => {
  * hold a list of subscribed reactors. When any value is written reactors are
  * re-run. Writing a reactor to a signal creates a lazy computed-signal. Signals
  * are named by the key of the object entry and a global counter. */
-const wireSignals = <T>(obj: T): {
-  [K in keyof T]: WireSignal<T[K] extends WireReactor<infer R> ? R : T[K]>;
+const signalPackage = <T>(obj: T): {
+  [K in keyof T]: WireSignal<T[K] extends WireSubscriber<infer R> ? R : T[K]>;
 } => {
-  type R = WireReactor<X>;
   Object.keys(obj).forEach((k) => {
-    let saved: unknown;
-    let read: unknown; // Multi-use temp variable
-    const id = `wS:${signalId++}{${k}}`;
-    const wS = { [id](...args: unknown[]) {
-      // Case: Read-Pass
-      if ((read = !args.length)) {
-        if (activeReactor) {
-          if (activeReactor.sS.has(wS)) {
-            throw new Error(`Mixed sS|sP ${wS.name}`);
-          }
-          activeReactor.sP.add(wS);
-        }
-      }
-      // Case: Void token
-      // eslint-disable-next-line no-empty
-      else if ((read = args[0] === v$)) {}
-      // Case: Read-Subscribe
-      // @ts-ignore
-      else if ((read = args[0] && args[0].$$ && args[0].wR)) {
-        if ((read as R).sP.has(wS)) {
-          throw new Error(`Mixed sP|sS ${wS.name}`);
-        }
-        (read as R).sS.add(wS);
-        wS.rS.add((read as R));
-        // Subscribing to a computed-signal also links cR's subscribed signals
-        wS.cR && wS.cR.sS.forEach((s) => {
-          // Link to sC not sS. This way the "Mixed A/B" errors keep working
-          (read as R).sC.add(s);
-          s.rS.add((read as R));
-        });
-      }
-      // Case: Write
-      else {
-        // If in a transaction; defer saving the value
-        if (transactionSignals) {
-          transactionSignals.add(wS);
-          wS.tV = args[0] as T[keyof T];
-          return;
-        }
-        // If overwriting a computed-signal, unsubscribe the reactor
-        if (wS.cR) {
-          reactorUnsubscribe(wS.cR);
-          delete wS.cR.cS; // Part of unsubscribing/cleaning the reactor
-          delete wS.cR;
-        }
-        saved = args[0] as T[keyof T];
-        // @ts-ignore If writing a reactor, register as a computed-signal
-        if (saved && saved.$wR) {
-          (saved as R).cS = wS;
-          (saved as R).state = STATE_STALE;
-          wS.cR = saved as R;
-        }
-        // Notify. Copy wS.wR since the Set() can grow while running and loop
-        // infinitely. Depth ordering needs an array while Sinuous uses a Set()
-        const toRun = [...wS.rS].sort((a, b) => a.sort - b.sort);
-        // Mark upstream computeds as stale. Must be in an isolated for-loop
-        toRun.forEach((wR) => {
-          if (wR.state === STATE_PAUSED || wR.cS) wR.state = STATE_STALE;
-        });
-        // Calls are ordered parent->child
-        toRun.forEach((wR) => {
-          // OFF|ON|RUNNING < PAUSED|STALE. Skips paused reactors and lazy
-          // computed-signals. OFF reactors shouldn't exist...
-          if (wR.state < STATE_PAUSED) wR();
-        });
-      }
-      if (read) {
-        if (wS.cR && wS.cR.state === STATE_STALE) saved = wS.cR();
-        return saved;
-      }
-    } }[id] as WireSignal;
-    wS.$wS = 1;
-    wS.rS = new Set<WireReactor<X>>();
-    // Call wS which runs the "Case: Write" to de|initialize computed-signals
-    wS(obj[k as keyof T]);
     // @ts-ignore Mutation of T
-    obj[k] = wS;
+    obj[k] = signal(obj[k as keyof T], k);
+    // Entire batch has same ID (object key order is undefined in the spec)
+    sigId--;
   });
   // @ts-ignore Mutation of T
   return obj;
+};
+
+const signal = <T>(value: T, id?: string): WireSignal<T> => {
+  type R = WireSubscriber<X>;
+  let saved: unknown;
+  // Multi-use temp variable
+  let read: unknown = `sig:${sigId++}{${id as string}`;
+  const sig = { [read as string](...args: unknown[]) {
+    // Case: Read-Pass
+    if ((read = !args.length)) {
+      if (activeSub) {
+        if (activeSub.sS.has(sig)) {
+          throw new Error(`Mixed sS|sP ${sig.name}`);
+        }
+        activeSub.sP.add(sig);
+      }
+    }
+    // Case: Void token
+    // eslint-disable-next-line no-empty
+    else if ((read = args[0] === v$)) {}
+    // Case: Read-Subscribe
+    // @ts-ignore
+    else if ((read = args[0] && args[0].$$ && args[0].wR)) {
+      if ((read as R).sP.has(sig)) {
+        throw new Error(`Mixed sP|sS ${sig.name}`);
+      }
+      (read as R).sS.add(sig);
+      sig.rS.add((read as R));
+      // Subscribing to a computed-signal also links cR's subscribed signals
+      sig.cR && sig.cR.sS.forEach((s) => {
+        // Link to sC not sS. This way the "Mixed A/B" errors keep working
+        (read as R).sC.add(s);
+        s.rS.add((read as R));
+      });
+    }
+    // Case: Write
+    else {
+      // If in a transaction; defer saving the value
+      if (transactionSignals) {
+        transactionSignals.add(sig);
+        sig.tV = args[0] as T;
+        return;
+      }
+      // If overwriting a computed-signal, unsubscribe the reactor
+      if (sig.cR) {
+        subClear(sig.cR);
+        delete sig.cR.cS; // Part of unsubscribing/cleaning the reactor
+        delete sig.cR;
+      }
+      saved = args[0] as T;
+      // @ts-ignore If writing a reactor, register as a computed-signal
+      if (saved && saved.$wR) {
+        (saved as R).cS = sig;
+        (saved as R).state = STATE_LINKED_STALE;
+        sig.cR = saved as R;
+      }
+      // Notify. Copy sig.rS since the Set() can grow while running and loop
+      // infinitely. Depth ordering needs an array while Sinuous uses a Set()
+      const toRun = [...sig.rS].sort((a, b) => a.sort - b.sort);
+      // Mark upstream computeds as stale. Must be in an isolated for-loop
+      toRun.forEach((sub) => {
+        if (sub.state === STATE_LINKED_PAUSED || sub.cS) sub.state = STATE_LINKED_STALE;
+      });
+      // Calls are ordered parent->child
+      toRun.forEach((wR) => {
+        // CLEARED|RUNNING|WAITING < PAUSED|STALE. Skips paused reactors and lazy
+        // computed-signals. RESET reactors shouldn't exist...
+        if (wR.state < STATE_LINKED_PAUSED) wR();
+      });
+    }
+    if (read) {
+      if (sig.cR && sig.cR.state === STATE_LINKED_STALE) saved = sig.cR();
+      return saved;
+    }
+  } }[read as string] as WireSignal<T>;
+  sig.$wS = 1;
+  sig.rS = new Set<WireSubscriber<X>>();
+  // Call it to run the "Case: Write" and de|initialize computed-signals
+  sig(value);
+  return sig;
 };
 
 /**
@@ -268,9 +273,9 @@ const transaction = <T>(fn: () => T): T => {
   const signals = transactionSignals;
   transactionSignals = prev;
   if (error) throw error;
-  signals.forEach((wS) => {
-    wS(wS.tV);
-    delete wS.tV;
+  signals.forEach((sig) => {
+    sig(sig.tV);
+    delete sig.tV;
   });
   return ret as T;
 };
@@ -279,9 +284,9 @@ const transaction = <T>(fn: () => T): T => {
  * Run a function with a reactor set as the active listener. Nested children
  * reactors are adopted (see wR.sort and wR.inner). This also affects signal
  * read consistent checks for read-pass (sP) and read-subscribe (sS). */
-const adopt = <T>(parentReactor: WireReactor<X>, fn: () => T): T => {
-  const prev = activeReactor;
-  activeReactor = parentReactor;
+const subAdopt = <T>(sub: WireSubscriber<X>, fn: () => T): T => {
+  const prev = activeSub;
+  activeSub = sub;
   let error: unknown;
   let ret: unknown;
   try {
@@ -289,21 +294,21 @@ const adopt = <T>(parentReactor: WireReactor<X>, fn: () => T): T => {
   } catch (err) {
     error = err;
   }
-  activeReactor = prev;
+  activeSub = prev;
   if (error) throw error;
   return ret as T;
 };
 
 export {
-  wireSignals,
-  wireSignals as wS,
-  wireReactor,
-  wireReactor as wR,
-  reactorUnsubscribe,
-  reactorPause,
+  signal,
+  signalPackage,
+  subscriber,
+  subscriber as sub,
+  subClear,
+  subPause,
+  subAdopt,
   transaction,
-  adopt,
   v$ // Actual subtokens are only ever provided by a reactor
 };
 
-export type { WireSignal, WireReactor, WireReactorState, SubToken };
+export type { WireSignal, WireSubscriber, WireSubscriberState, SubToken };


### PR DESCRIPTION
Related to #5. Naming is very hard. Naming is also an important part of the library for many debugging reasons (see #5). I want the names of exports to make sense since they're two sides to the same coin and don't do much alone. I had previously chosen WireSignal & WireReactor to show that they're related by a prefix. This was really long for inline JSX so wS/wR was used too. This wasn't great for readability (also commented in #2) and therefore also wasn't very explicit/meaningful. I also learned that people hear "reactor" and think of nuclear reactors, which is surprising and not what I meant.

The names need to fit together, but they also need to be short. A replacement for "reactor" needs to fit nicely for inlined JSX. In #5 I proposed "sub". Other attempts were: (repeat) `rep()`, (subscribe) `sub()`, `link()`, (connect) `con()`, `anew()`, (socket) `sock()`, `sync()`, ...

I've picked WireSignal and WireCore right now.

Here are the new exports of Haptic Wire:

```ts
export {
  signal,
  signalsFrom,
  core,
  coreReset,
  corePause,
  coreAdopt,
  transaction,
  v$
};
```

TypeScript will still show the functions created by `signal()`/`signalsFrom()` and `core()` as WireSignal and WireCore respectively, which is good since I want them to be related by a prefix. There's a new export, `signal`, which creates an unnamed signal. The original form of signal creation using an object (which encourages/simplifies naming to help debugging) is now `signalsFrom`. I also changed "adopt" to show that it's to be used for cores. Internally, some FSM names were changed and the function properties on signals and cores now have nice closer-to-full-length names such as "signalRS" rather than "sS"; JSDoc describes these.

This hurts bundle size (see commits) but I'm trying to care about that less.