### PR TITLE
Addressing FSM-ambiguity in wires 

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,11 +11,9 @@ const entryPoints = [
 
 // About 100 characters saved this way
 const define = {
-  FSM_RESET: 0,
-  FSM_RUNNING: 1,
-  FSM_WIRED_IDLE: 2,
-  FSM_WIRED_PAUSED: 3,
-  FSM_WIRED_STALE: 4,
+  S_RUNNING: 4,
+  S_SKIP_RUN_QUEUE: 2,
+  S_NEEDS_RUN: 1,
 };
 
 // This is explained in ./src/index.ts. Haptic's bundle entrypoint isn't a self

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "node build.js",
     "types": "tsc --project tsconfig.json",
-    "bundlesize": "echo $(esbuild --bundle src/bundle.ts --format=esm --minify --define:FSM_RESET=0 --define:FSM_RUNNING=1 --define:FSM_WIRED_IDLE=2 --define:FSM_WIRED_PAUSED=3 --define:FSM_WIRED_STALE=4 | gzip -9 | wc -c) min+gzip bytes"
+    "bundlesize": "echo $(esbuild --bundle src/bundle.ts --format=esm --minify --define:S_RUNNING=4 --define:S_SKIP_RUN_QUEUE=2 --define:S_NEEDS_RUN=1 | gzip -9 | wc -c) min+gzip bytes"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.28.4",

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -8,9 +8,7 @@ export { signal, wire } from './state/index.js';
   --bundle src/bundle.ts
   --format=esm
   --minify
-  --define:FSM_RESET=0
-  --define:FSM_RUNNING=1
-  --define:FSM_WIRED_IDLE=2
-  --define:FSM_WIRED_PAUSED=3
-  --define:FSM_WIRED_STALE=4 | gzip -9 | wc -c
+  --define:S_RUNNING=4
+  --define:S_SKIP_RUN_QUEUE=2
+  --define:S_NEEDS_RUN=1 | gzip -9 | wc -c
 */

--- a/src/dom/index.ts
+++ b/src/dom/index.ts
@@ -22,9 +22,7 @@ const api: {
   patch: (
     value: unknown,
     // Reactivity could be from Haptic, Sinuous, MobX, Hyperactiv, etc
-    // Return `value` so a wire can be reused in multiple DOM nodes via chaining
-    // TODO: Test (#3)
-    patchDOM?: <T = unknown>(value: T) => T,
+    patchDOM?: (value: unknown) => void,
     // Element being patched
     el?: Node,
     // If this is patching an element property, this is the attribute

--- a/src/dom/nodeInsert.ts
+++ b/src/dom/nodeInsert.ts
@@ -39,9 +39,9 @@ const insert = (el: Node, value: unknown, endMark?: Node, current?: Node | Frag,
     // @ts-expect-error Reusing the variable but doesn't match the signature
     current = value;
   }
-  // Sorry this is cryptic. Bundlesize. Comma-operator returns v after api call.
-  else if (api.patch(value, (v) =>
-    (current = api.insert(el, v, endMark, current, startNode), v), el)
+  else if (
+    api.patch(value, (v) =>
+      current = api.insert(el, v, endMark, current, startNode), el)
   ) {}
   else {
     // Block for Node, Fragment, Array, Functions, etc. This stringifies via h()

--- a/src/dom/nodeProperty.ts
+++ b/src/dom/nodeProperty.ts
@@ -25,9 +25,8 @@ export const property = (el: Node, value: unknown, name: string | null, isAttr?:
     el.addEventListener(name, value as EventHandler);
     listeners[name] = value as EventHandler;
   }
-  // Sorry this is cryptic. Bundlesize. Comma-operator returns v after api call.
-  else if (api.patch(value, (v) =>
-    (api.property(el, v, name, isAttr, isCss), v), el, name)
+  else if (
+    api.patch(value, (v) => api.property(el, v, name, isAttr, isCss), el, name)
   ) {}
   else if (isCss) {
     (el as HTMLElement | SVGElement).style.setProperty(name, value as string);

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,9 +30,8 @@ api.patch = (value, patchDOM) => {
   // I like type fields that use 1 instead of true/false, so convert via `!!`
   // eslint-disable-next-line no-implicit-coercion
   const $wire = (value && !!(value as Wire).$wire) as boolean;
-  const { fn } = value as Wire;
   if ($wire && patchDOM) {
-    (value as Wire).fn = ($) => patchDOM(fn($));
+    (value as Wire).tasks.add(patchDOM);
     (value as Wire)();
   }
   return $wire;


### PR DESCRIPTION
## Issues with wire state

Wires are driven as a Finite State Machine (FSM). This is a one-dimensional value; internally a integer from 0 to 4.

```ts
type Wire<T> = {
  // ...
  /** FSM state: RESET|RUNNING|IDLE|PAUSED|STALE */
  state: WireFSM;
  // ...
};

type WireFSM =
  | FSM_RESET
  | FSM_RUNNING
  | FSM_WIRED_IDLE
  | FSM_WIRED_PAUSED
  | FSM_WIRED_STALE;
```

### Where state is used today

The 0-4 states are used here:

- In `wire` (aka `createWire`) during creation:
  - Sets RESET
- In `wire` during a run:
  - Throws if RUNNING is already set (infinite loop check)
  - If PAUSED
    - Sets IDLE OR RESET depending if there were subscribers (sigRS)
    - Repeats this for all `wire.inner` children
  - Else
    - Sets RESET as part of `wireReset`
    - Sets RUNNING for `wire.fn()` call duration
    - Sets IDLE OR RESET depending if there were subscribers (sigRS)
- In `_runWires` before calling wires:
  - Moving from PAUSED -> STALE if needed _(i.e STALE means PAUSED_AND_STALE)_
  - Calling a wire if it's NOT PAUSED AND NOT STALE _(i.e PAUSED_AND_STALE)_
- In `wirePause`:
  - Sets PAUSED for this wire and all inner wires

This already has problems, seen right in the FSM names themselves: I'm overloading terms to imply, for instance, that a wire can never be idle and stale, and that a stale wire _is_ a paused wire. This gets really messy with the introduction of computed-signals that _also_ have a stale state (which is stale but never paused; _oh no_) and needs to be skipped _somehow_ possibly via another state.

- In `signal` (aka `signalBase`) during a read-subscribe:
  - If this is computed-signal whose wire is STALE or NOT_WIRED, run it
- In `signal` during any read (pass or subscribe):
  - If this is computed-signal whose wire is STALE or NOT_WIRED, run it
- In `signal` when writing a wire:
  - If this is computed-signal already
    - Set saved wire as RESET
  - Set incoming wire as STALE (so `_runWires` doesn't call it)
- In `_runWires`:
  - First loop: If wire belongs to a computed-signal set to STALE
  - Second loop: If wire is PAUSED or STALE skip it

### Issues with this state model

Note that I'm not interested in trying to prevent people from explicitly doing bad things like `wire.state = xyz`. I just don't want to introduce unexpected or accidental state transitions.

Here are some of those pitfalls:

- If you call `wirePause` during the wire function run (`wire.fn`) you can move your own state from RUNNING into PAUSED skipping infinite loop detection (!).

- Calling a wire to unpause is magic. Especially since it breaks the principal _"Wires can always be run manually by calling them and this won't cause other side-effects within the engine."_

- Calling a wire of a computed-signal removes its STALE state but _doesn't_ update the stored value of the computed-signal **This breaks the signal** until the wire is marked STALE again.

- Computed-signal can be initialized with _any wire_ including ones that are PAUSED or that have already had their function wrapped to support DOM patching. When the computed-signal is taken down (writing a value so it becomes a normal signal) the wire is set to RESET. **This breaks the wire** and prevents it from doing any other tasks such as DOM patching since all subscriptions have been removed. There's no way to know it had other tasks; they're lost in the wrapping.

- Although computed-signals are set as STALE in `_runWires`, it's possible that they'll run somehow and end up as IDLE between the 1st and 2nd run loops. This means `_runWires` _must_ check `wire.cs` and not rely only on state... Is belonging to a computed-signal a state now?

- It doesn't make sense to pause a computed-signal but it's not good enough to just hope they don't try pausing it; it can happen _accidentally_. This happens in wire function wrapping (used to patch a single wire into multiple areas of the DOM; i.e chaining). If one of those chains was in a `when()` block, the wire would be re-adopted and `when()` would pause _all_ patches, not only its child elements.

### Issues with chaining

The issue above about chaining is very concerning. It also came up when I tried fixing computed-signal's to have their saved value updated when a wire is manually run - a small optimization but worth considering.

Why not just wrap the wire function like DOM patching does? The value will be updated via closure...

It'd be **impossible to undo**. Computed-signals need to be taken down, and there's no way to unwrap a function. It's also not safe to restore to the previously seen function since the wire could have been wrapped again during the computed-signal's lifetime.

## Fixes

This is how I'm trying to address all these issues...

### Both pause and resume should be dedicated methods

Wires should always run when manually called since it's their expected behaviour. Don't have a magic "unpausing" call. This means a new `wireResume` next to `wirePause`.

It'll drop bundle size.

### Replace chaining with a `Set` of post-run calls

It's not clear, explicit, and debuggable to have a dedicated `wire.hooks` `Set` that tracks all the post-run actions. During takedown of a computed-signals I can use `wire.hooks.delete(...)` via function reference.

Might add bundle size.

### Split state into a bitmask

I've seen projects like Kairo do that. It could be smaller than adding more individual properties like `wire.paused`.

It'll add to bundle size.

Here's how I broke it down:

```js
[IS_CW][IS_WIRED][IS_RUNNING][IS_PAUSED][IS_STALE]
```

I can drop IS_CW and use `wire.cs` instead. This is a two-way link between a signal and wire. It's there for principles of consistency and debugging, so I'm keeping it. I can drop IS_WIRED and use `wire.sigRS` as well.

```js
[IS_RUNNING][IS_PAUSED][IS_STALE]
```

I'm still overloading the term "stale" which mostly means "skip" in `_runWires` context and "run later" in other contexts.

```js
[IS_RUNNING][SKIP_ME][WAS_SKIPPED]
```

Lastly I need to convey that a skipped wire is overdue for a run. I'd also like `wireReset` to be able to indicate that it's uninitialized; `wire.run` doesn't work since wires can always be manually reset even after they're run.

```js
[RUNNING][SKIP_RUN_QUEUE][NEEDS_RUN]
```

Here's how this works for the above cases:

Pause/Resume:
  - `wirePause`: Sets SKIP_RUN_QUEUE. Has no impact to computed-signals because they already have
    SKIP_RUN_QUEUE.
  - `_runWires`: If SKIP_RUN_QUEUE is set then set NEEDS_RUN. This is the same for computed-signals
    too.
  - `wireResume`: Clears SKIP_RUN_QUEUE only if it's NOT a computed-signal.

Computed-signals:
  - `signal` setup: Sets SKIP_RUN_QUEUE, `wire.cs`, and `wire.hooks.add(...)`.
  - `signal` read-subscribe: If NEEDS_RUN, run.
  - `signal` any read (pass or subscribe): If NEEDS_RUN, run.
  - `_runWires`: If SKIP_RUN_QUEUE is set then set NEEDS_RUN. This is the same for paused wires too.
  - `signal` takedown: Uses `wireReset` (clears state; sets _only_ NEEDS_RUN). Uses `delete wire.cs`
    and `wire.hooks.delete(...)`.

Reset via `wireReset`:
  - Clears all state and sets only NEEDS_RUN. Because it's not idling yet? This helps computed-signals know to auto-run the wire on read to initialize the wire's `sigRS` and propagate subscriptions (i.e `sigIC`).
  - TODO: Benchmark:
    - `if (wire.sigIC.size) wire.sigIC = new Set()` vs
    - `wire.sigIC = new Set()` vs
    - `wire.sigIC.clear()`

Scenarios that are fixed using this model:

  - Mark a wire as paused (sets SKIP_RUN_QUEUE), have a signal try to run it (sets NEEDS_RUN), and then manually run it - it'll clear NEEDS_RUN but leaves it as SKIP_RUN_QUEUE so it's still paused.

  - Resume a wire during it's wire run - it doesn't break the RUNNING state.

  - Manually run a computed-signal's wire that is in NEEDS_RUN - it'll clear NEEDS_RUN and update the signal's saved value using `wire.hooks`.

  - Create a computed-signal using an existing/used wire - it sets SKIP_RUN_QUEUE (has no effect on pausing/resuming since they respect `wire.cs`). If the wire has never run it'll be in NEEDS_RUN and I'll run it; else it'll be idle\* and nothing happens. It's always safe to use `sigRS`.

Other considerations:

  - I don't warn or throw if the wire they pass has an empty `sigRS`. If they pass an unrunnable wire with no subscriptions it should be easy to debug outside of a computed-signal. Not my problem.

  - Regarding the \*; it _has_ to be idling (RUNNING=0) since if it was (RUNNING && NEEDS_RUN) they'd be initializing the computed-signal within the running wire and it'll throw a loop error.
